### PR TITLE
Add http endpoint for adding tags to a specific release channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/ais.py
+++ b/ais.py
@@ -2,6 +2,7 @@ from flask import Flask, request, make_response, abort
 import json
 import boto3
 from datetime import datetime
+import os
 
 app = Flask(__name__)
 
@@ -18,7 +19,7 @@ def tag(namespace, tag):
 
 def _write_to_s3(namespace, tag, data):
     s3 = boto3.resource('s3')
-    s3object = s3.Object(app.config.get('S3BUCKET'), '%s/%s.json' % (namespace, tag))
+    s3object = s3.Object(os.environ['S3BUCKET'], '%s/%s.json' % (namespace, tag))
     s3object.put(Body=json.dumps(data, indent=4))
 
 
@@ -34,7 +35,6 @@ def health():
 
 
 def main():
-    app.config.from_pyfile('config.cfg')
     app.run()
 
 

--- a/ais.py
+++ b/ais.py
@@ -7,11 +7,6 @@ app = Flask(__name__)
 app.config.from_pyfile('config.cfg')
 
 
-@app.route('/')
-def hello_world():
-    return 'Hello World!'
-
-
 @app.route('/<namespace>/<tag>', methods=['POST'])
 def tag(namespace, tag):
     data = request.get_json(force=True)

--- a/ais.py
+++ b/ais.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, make_response, abort
 import json
 import boto3
+from datetime import datetime
 
 app = Flask(__name__)
 app.config.from_pyfile('config.cfg')
@@ -14,6 +15,8 @@ def hello_world():
 @app.route('/<namespace>/<tag>', methods=['POST'])
 def tag(namespace, tag):
     data = request.get_json(force=True)
+    if 'updated' not in data:
+        data['updated'] = datetime.now().isoformat()
     _verify(data)
     _write_to_s3(namespace, tag, data)
     return make_response('', 200)

--- a/ais.py
+++ b/ais.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, make_response
 
 app = Flask(__name__)
 
@@ -6,6 +6,11 @@ app = Flask(__name__)
 @app.route('/')
 def hello_world():
     return 'Hello World!'
+
+
+@app.route('/_/health')
+def health():
+    return make_response('', 200)
 
 
 def main():

--- a/ais.py
+++ b/ais.py
@@ -7,19 +7,19 @@ import os
 app = Flask(__name__)
 
 
-@app.route('/<namespace>/<tag>', methods=['POST'])
-def tag(namespace, tag):
+@app.route('/<channel>/<tag>', methods=['POST'])
+def tag(channel, tag):
     data = request.get_json(force=True)
     if 'updated' not in data:
         data['updated'] = datetime.now().isoformat()
     _verify(data)
-    _write_to_s3(namespace, tag, data)
+    _write_to_s3(channel, tag, data)
     return make_response('', 200)
 
 
-def _write_to_s3(namespace, tag, data):
+def _write_to_s3(channel, tag, data):
     s3 = boto3.resource('s3')
-    s3object = s3.Object(os.environ['S3BUCKET'], '%s/%s.json' % (namespace, tag))
+    s3object = s3.Object(os.environ['S3BUCKET'], '%s/%s.json' % (channel, tag))
     s3object.put(Body=json.dumps(data, indent=4))
 
 

--- a/ais.py
+++ b/ais.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 app = Flask(__name__)
 
+
 @app.route('/<namespace>/<tag>', methods=['POST'])
 def tag(namespace, tag):
     data = request.get_json(force=True)

--- a/ais.py
+++ b/ais.py
@@ -1,11 +1,27 @@
-from flask import Flask, make_response
+from flask import Flask, request, make_response
+import json
+import boto3
 
 app = Flask(__name__)
+app.config.from_pyfile('config.cfg')
 
 
 @app.route('/')
 def hello_world():
     return 'Hello World!'
+
+
+@app.route('/<namespace>/<tag>', methods=['POST'])
+def tag(namespace, tag):
+    data = request.get_json(force=True)
+    _write_to_s3(namespace, tag, data)
+    return make_response('', 200)
+
+
+def _write_to_s3(namespace, tag, data):
+    s3 = boto3.resource('s3')
+    s3object = s3.Object(app.config.get('S3BUCKET'), '%s/%s.json' % (namespace, tag))
+    s3object.put(Body=json.dumps(data, indent=4))
 
 
 @app.route('/_/health')

--- a/ais.py
+++ b/ais.py
@@ -4,8 +4,6 @@ import boto3
 from datetime import datetime
 
 app = Flask(__name__)
-app.config.from_pyfile('config.cfg')
-
 
 @app.route('/<namespace>/<tag>', methods=['POST'])
 def tag(namespace, tag):
@@ -35,6 +33,7 @@ def health():
 
 
 def main():
+    app.config.from_pyfile('config.cfg')
     app.run()
 
 

--- a/config.cfg
+++ b/config.cfg
@@ -1,1 +1,0 @@
-S3BUCKET = 'my-s3-bucket'

--- a/config.cfg
+++ b/config.cfg
@@ -1,0 +1,1 @@
+S3BUCKET = 'my-s3-bucket'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def version():
 
 GENERIC_REQ = [
     "Flask==0.12.2",
-    "boto3==1.4.4",
+    "boto3==1.5.24",
     "moto==1.2.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def version():
 
 GENERIC_REQ = [
     "Flask==0.12.2",
+    "boto3==1.4.4",
 ]
 
 CODE_QUALITY_REQ = [

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def version():
 GENERIC_REQ = [
     "Flask==0.12.2",
     "boto3==1.4.4",
+    "moto==1.2.0",
 ]
 
 CODE_QUALITY_REQ = [

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8
-
-import ais
-
-
-def test_dummy():
-    assert ais.hello_world() == "Hello World!"

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -26,8 +26,8 @@ class S3TestCase(TestCase):
         data = dict(zip(keys, keys))
         data['updated'] = datetime.now().isoformat()
 
-        self.client.post('/namespace/tag', data=json.dumps(data))
+        self.client.post('/channel/tag', data=json.dumps(data))
 
-        body = json.load(self.conn.Object(self.mybucket, 'namespace/tag.json').get()['Body'])
+        body = json.load(self.conn.Object(self.mybucket, 'channel/tag.json').get()['Body'])
 
         assert body == data

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -7,16 +7,18 @@ from unittest import TestCase
 from datetime import datetime
 import json
 import boto3
+import os
 
 
 @mock_s3
 class S3TestCase(TestCase):
     def setUp(self):
+        self.mybucket = 'mybucket'
+        os.environ['S3BUCKET'] = self.mybucket
         self.conn = boto3.resource('s3')
-        self.conn.create_bucket(Bucket='mybucket')
+        self.conn.create_bucket(Bucket=self.mybucket)
 
         self.app = ais.app
-        self.app.config['S3BUCKET'] = 'mybucket'
         self.client = ais.app.test_client()
 
     def test_persist_tag_to_s3(self):
@@ -26,6 +28,6 @@ class S3TestCase(TestCase):
 
         self.client.post('/namespace/tag', data=json.dumps(data))
 
-        body = json.load(self.conn.Object('mybucket', 'namespace/tag.json').get()['Body'])
+        body = json.load(self.conn.Object(self.mybucket, 'namespace/tag.json').get()['Body'])
 
         assert body == data

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import ais
+from moto import mock_s3
+from unittest import TestCase
+from datetime import datetime
+import json
+import boto3
+
+
+@mock_s3
+class S3TestCase(TestCase):
+    def setUp(self):
+        self.conn = boto3.resource('s3')
+        self.conn.create_bucket(Bucket='mybucket')
+
+        self.app = ais.app
+        self.app.config['S3BUCKET'] = 'mybucket'
+        self.client = ais.app.test_client()
+
+    def test_persist_tag_to_s3(self):
+        keys = ['updated', 'image', 'commit', 'build']
+        data = dict(zip(keys, keys))
+        data['updated'] = datetime.now().isoformat()
+
+        self.client.post('/namespace/tag', data=json.dumps(data))
+
+        body = json.load(self.conn.Object('mybucket', 'namespace/tag.json').get()['Body'])
+
+        assert body == data


### PR DESCRIPTION
This adds an endpoint where namespace tag metadata in json format can be posted to. The metadata will be stored in a s3 bucket associated with the namespace and tag. This way multiple tags and namespaces are supported.