### PR TITLE
Build and push docker images from travis ci as part of build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,267 @@
+# Created by .ignore support plugin (hsz.mobi)
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Emacs template
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+*.iml
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - '3.6'
+- '3.6'
 cache: pip
-install:
-  - pip install -e .[ci]
 env:
-  - COVERAGE=""
-  - COVERAGE="-e coverage"
-script: tox ${COVERAGE}
+install:
+- pip install -e .[ci]
+script:
+  - tox
+after_success: tox -e coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: python
 python:
 - '3.6'
+sudo: required
+services:
+- docker
 cache: pip
 env:
+  global:
+  - DOCKER_USERNAME=captainfiaas
+  - secure: rqpEgRnrN4TY9mr+9feZ74afJ015FEyRQi/sm50wqrBVJezPsNnH2mkkxAUSRABAAOhAH4r9qSCf6V3HAT5lTvyxuxlsskmrLj4jXHRNhT6g+ZV3aIekbX+og4i8V2Ap5kt2BQ2NHeOQLGI+LEYU4reaO1fishTssYPj0bBR0KdOyfj+y1+ilpYUgfRdDsX/fWisfdaYjm/HLUJ1SIz/poTSLhEGpk1JAvpe3YlUaUoDs/GfdOnOAyH5PWlwH8xU31WjoHrDVR6gRlbpk73Y65hbBMFTruy1011C7kWGFbdCG25MZbW3a54ZYGXFaiyvk4r3HlIOsWHSA+1kzqW8rrbjT67PqCp/rJMe6fXoNARvvRhrmC5EsO83L1xGNgwTR3/WvO6l+z/NTXHkQhGRtCXXr6kMXr4XbL7FJhJF6nQllIRNAcnbnW0cjOQQCvTJiLuOIoDZaZQyESmVvbO8dDIavd3rQDxhfXzfA/dHTzOv2dRtplRTYkOtSmdBwtKRTLrkpWIjGMl1nwOWXe8EeUBYY0mLfL9kVWUvTOAS1iLVkLBK+TIyHp3R4o1BIVcTFVbWsUByAjnrHda6FIjdMi2WXIo+eFnlLC/Zy5Dtj6NmVFq2+YjRQlrXqimqacex44QTOOfVBWlDPBIcRBYHTag718knX6J+z4hR0Zv1dO0= # DOCKER_PASSWORD todo replace with correct encrypted secret
 install:
 - pip install -e .[ci]
 script:
   - tox
+  - bin/docker_build
 after_success: tox -e coverage
+deploy:
+  provider: script
+  script: bin/docker_push
+  skip_cleanup: true
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   global:
   - DOCKER_USERNAME=captainfiaas
   - secure: rqpEgRnrN4TY9mr+9feZ74afJ015FEyRQi/sm50wqrBVJezPsNnH2mkkxAUSRABAAOhAH4r9qSCf6V3HAT5lTvyxuxlsskmrLj4jXHRNhT6g+ZV3aIekbX+og4i8V2Ap5kt2BQ2NHeOQLGI+LEYU4reaO1fishTssYPj0bBR0KdOyfj+y1+ilpYUgfRdDsX/fWisfdaYjm/HLUJ1SIz/poTSLhEGpk1JAvpe3YlUaUoDs/GfdOnOAyH5PWlwH8xU31WjoHrDVR6gRlbpk73Y65hbBMFTruy1011C7kWGFbdCG25MZbW3a54ZYGXFaiyvk4r3HlIOsWHSA+1kzqW8rrbjT67PqCp/rJMe6fXoNARvvRhrmC5EsO83L1xGNgwTR3/WvO6l+z/NTXHkQhGRtCXXr6kMXr4XbL7FJhJF6nQllIRNAcnbnW0cjOQQCvTJiLuOIoDZaZQyESmVvbO8dDIavd3rQDxhfXzfA/dHTzOv2dRtplRTYkOtSmdBwtKRTLrkpWIjGMl1nwOWXe8EeUBYY0mLfL9kVWUvTOAS1iLVkLBK+TIyHp3R4o1BIVcTFVbWsUByAjnrHda6FIjdMi2WXIo+eFnlLC/Zy5Dtj6NmVFq2+YjRQlrXqimqacex44QTOOfVBWlDPBIcRBYHTag718knX6J+z4hR0Zv1dO0= # DOCKER_PASSWORD todo replace with correct encrypted secret
+before_install:
+- sudo rm -f /etc/boto.cfg # Fix to avoid problems importing boto
 install:
 - pip install -e .[ci]
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM python:alpine
+FROM python:3.6-alpine3.7 as common
 MAINTAINER fiaas@googlegroups.com
+# Install any binary package dependencies here
+RUN apk --no-cache add \
+    yaml
+
+FROM common as build
+# Install build tools, and build wheels of all dependencies
+RUN apk --no-cache add \
+    build-base \
+    git \
+    yaml-dev
 COPY . /ais
 WORKDIR /ais
-RUN pip install .
+RUN pip wheel . --wheel-dir=/wheels/
+
+FROM common as production
+# Get rid of all build dependencies, install application using only pre-built binary wheels
+COPY --from=build /wheels/ /wheels/
+RUN pip install --no-index --find-links=/wheels/ --only-binary all /wheels/fiaas_ais*.whl
+EXPOSE 5000
 CMD ["ais"]

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -evuo pipefail
+
+docker build . -t "${TRAVIS_REPO_SLUG}:latest"

--- a/bin/docker_push
+++ b/bin/docker_push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -evuo pipefail
+
+VERSION=$(python setup.py --version)
+DOCKER_IMAGE="${TRAVIS_REPO_SLUG}:${VERSION/+/-}"
+
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+docker tag "${TRAVIS_REPO_SLUG}:latest" "${DOCKER_IMAGE}"
+
+if [[ "${CI}" == "true" ]]; then
+    docker push "${TRAVIS_REPO_SLUG}"
+    echo "Pushed image ${DOCKER_IMAGE}"
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,8 @@ commands=prospector
 
 [testenv:coverage]
 usedevelop=True
-deps=.[dev,codacy]
+deps=.[codacy]
 passenv =
     HOME
     CODACY_PROJECT_TOKEN
-commands=py.test
-         python-codacy-coverage -r ./build/reports/coverage.xml
+commands=python-codacy-coverage -r ./build/reports/coverage.xml


### PR DESCRIPTION
This replicates some of the adjustments made in fiaas/skipper to build and push docker images as part of ci that makes using automatic building in dockerhub unnecessary.